### PR TITLE
Derive comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ type t =
   | And of t * t
   | Or of t * t
   | Not of t
-[@@deriving show, popper]
+[@@deriving show, eq, popper]
 
 let rec eval = function
   | Lit b -> b
@@ -68,8 +68,34 @@ let test_and =
 let () = Test.run test_and
 ```
 
-Gives:
+Yields:
 
 ![image](https://user-images.githubusercontent.com/820478/113483019-43015500-9499-11eb-8302-de90ce5deefc.png)
 
+### Deriving comparators
+
+An example of using a derived comparator.
+
+```ocaml
+open Popper
+open Generator.Syntax
+
+type t =
+  { x_values : int list
+  ; y_values : int list
+  ; x_axis : string
+  ; y_axis : string
+  }
+[@@deriving show, eq, popper]
+
+let flip { x_values; y_values; x_axis; y_axis } =
+  { x_values = y_values; y_values = x_values; x_axis = y_axis; y_axis = x_axis }
+
+let test_flip_twice =
+  Test.test (fun () ->
+    let* s = generate in
+    Test.equal comparator (flip (flip s)) s)
+
+let suite = Test.suite [ ("Flip chart", test_flip) ]
+```
 

--- a/examples/arithmetic.ml
+++ b/examples/arithmetic.ml
@@ -11,13 +11,13 @@ type point =
   { x : int
   ; y : int
   }
-[@@deriving show, popper]
+[@@deriving show, eq, popper]
 
 let point_sum p1 p2 : point =
   { x = simple_sum p1.x p2.x; y = simple_sum p1.y p2.y }
 
 let test_sum =
-  Test.test ~count:50 (fun () ->
+  Test.test (fun () ->
     (* Getting two built-in generators *)
     let* left = int in
     let* right = int in
@@ -30,7 +30,7 @@ let test_sum =
     Test.equal comparator actual expected)
 
 let test_diff =
-  Test.test ~count:50 (fun () ->
+  Test.test (fun () ->
     (* Getting two built-in generators *)
     let* left = int in
     let* right = int in
@@ -41,17 +41,15 @@ let test_diff =
     Test.equal comparator actual expected)
 
 let test_point_sum =
-  Test.test ~count:50 (fun () ->
+  Test.test (fun () ->
     let* left = generate_point in
     let* right = generate_point in
     let expected = { x = left.x + right.x; y = left.y + right.y } in
     let actual = point_sum left right in
-    (* Skip using comparators and pretty printers, however this doesn't
-    print the failing case *)
-    Test.is_true (actual = expected))
+    Test.equal ~loc:__LOC__ point_comparator expected actual)
 
 let test_division =
-  Test.test ~count:100 (fun () ->
+  Test.test (fun () ->
     let* x = range (-10) 10 in
     let* y = range (-10) 10 in
     let expected = if y = 0 then None else Some (x / y) in

--- a/examples/chart.ml
+++ b/examples/chart.ml
@@ -7,16 +7,14 @@ type t =
   ; x_axis : string
   ; y_axis : string
   }
-[@@deriving show, popper]
+[@@deriving show, eq, popper]
 
 let flip { x_values; y_values; x_axis; y_axis } =
   { x_values = y_values; y_values = x_values; x_axis = y_axis; y_axis = x_axis }
 
-let comparator = Comparator.make ( = ) pp
-
 let test_flip =
-  Test.test ~count:1000 (fun () ->
+  Test.test (fun () ->
     let* s = generate in
     Test.equal comparator (flip s) s)
 
-let suite = Test.suite [ ("Flip series", test_flip) ]
+let suite = Test.suite [ ("Flip chart", test_flip) ]

--- a/examples/dune
+++ b/examples/dune
@@ -2,4 +2,8 @@
  (name run)
  (libraries alcotest containers popper)
  (preprocess
-  (pps ppx_deriving.make ppx_deriving.show ppx_deriving_popper)))
+  (pps
+   ppx_deriving.make
+   ppx_deriving.show
+   ppx_deriving.eq
+   ppx_deriving_popper)))

--- a/examples/exp.ml
+++ b/examples/exp.ml
@@ -6,7 +6,7 @@ type t =
   | And of t * t
   | Or of t * t
   | Not of t
-[@@deriving show, popper]
+[@@deriving show, eq, popper]
 
 let rec eval = function
   | Lit b -> b


### PR DESCRIPTION
Deriving `popper` now also generates comparators.

An example of using a derived comparator.

```ocaml
open Popper
open Generator.Syntax

type t =
  { x_values : int list
  ; y_values : int list
  ; x_axis : string
  ; y_axis : string
  }
[@@deriving show, eq, popper]

let flip { x_values; y_values; x_axis; y_axis } =
  { x_values = y_values; y_values = x_values; x_axis = y_axis; y_axis = x_axis }

let test_flip_twice =
  Test.test (fun () ->
    let* s = generate in
    Test.equal comparator (flip (flip s)) s)

let suite = Test.suite [ ("Flip chart", test_flip) ]
```
