### PR TITLE
Fix size distribution

### DIFF
--- a/src/lib/output.ml
+++ b/src/lib/output.ml
@@ -3,15 +3,10 @@ type 'a t =
   ; consumed : Consumed.t
   ; remaining : Input.t
   ; log : Log.t
-  ; size : int
   }
 
-let make ~value ~size ~consumed ~remaining ~log =
-  { size; value; consumed; remaining; log }
-
+let make ~value ~consumed ~remaining ~log = { value; consumed; remaining; log }
 let value { value; _ } = value
-let size { size; _ } = size
-let set_size size v = { v with size }
 let consumed { consumed; _ } = consumed
 let set_consumed consumed output = { output with consumed }
 let set_value value output = { output with value }
@@ -20,9 +15,9 @@ let remaining { remaining; _ } = remaining
 let log { log; _ } = log
 let set_log log output = { output with log }
 
-let map f { size; value; consumed; remaining; log } =
-  { value = f value; size; consumed; remaining; log }
+let map f { value; consumed; remaining; log } =
+  { value = f value; consumed; remaining; log }
 
-let tag tag { value; size; consumed; remaining; log } =
+let tag tag { value; consumed; remaining; log } =
   let consumed = Consumed.tag tag consumed in
-  { value; size; consumed; remaining; log }
+  { value; consumed; remaining; log }

--- a/src/lib/output.mli
+++ b/src/lib/output.mli
@@ -2,15 +2,12 @@ type 'a t
 
 val make
   :  value:'a
-  -> size:int
   -> consumed:Consumed.t
   -> remaining:Input.t
   -> log:Log.t
   -> 'a t
 
 val set_consumed : Consumed.t -> 'a t -> 'a t
-val size : 'a t -> int
-val set_size : int -> 'a t -> 'a t
 val log : 'a t -> Log.t
 val set_log : Log.t -> 'a t -> 'a t
 val set_remaining : Input.t -> 'a t -> 'a t

--- a/src/lib/popper.mli
+++ b/src/lib/popper.mli
@@ -94,6 +94,9 @@ module Sample : sig
       combines their result. *)
   val both : 'a t -> 'b t -> ('a * 'b) t
 
+  (** [size] returns the current [max-size] argument. *)
+  val size : int t
+
   (** [sized f] lifts the function [f] that depend on a size argument to a
       sample. *)
   val sized : (int -> 'a t) -> 'a t

--- a/src/lib/random.ml
+++ b/src/lib/random.ml
@@ -41,15 +41,9 @@ let map f { run } =
 
 let delayed f = make (fun seed -> run seed @@ f ())
 
-let time f x =
-  let start = Unix.gettimeofday () in
-  let res = f x in
-  let stop = Unix.gettimeofday () in
-  (res, stop -. start)
-
 let timed { run } =
   make (fun seed ->
-    let (x, s), t = time run seed in
+    let (x, s), t = Util.Timer.time_it @@ fun () -> run seed in
     ((x, t), s))
 
 let pair r1 r2 = bind r1 (fun x -> bind r2 (fun y -> return (x, y)))

--- a/src/lib/sample.mli
+++ b/src/lib/sample.mli
@@ -5,6 +5,7 @@ val map : ('a -> 'b) -> 'a t -> 'b t
 val return : 'a -> 'a t
 val bind : 'a t -> ('a -> 'b t) -> 'b t
 val both : 'a t -> 'b t -> ('a * 'b) t
+val size : int t
 val sized : (int -> 'a t) -> 'a t
 val resize : int -> 'a t -> 'a t
 val one_of : 'a t list -> 'a t

--- a/src/lib/shrink.ml
+++ b/src/lib/shrink.ml
@@ -197,10 +197,10 @@ let shrink
   ~max_tries
   ~max_tries_modify
   ~num_shrink_rounds
+  ~size
   output
   (gen : Proposition.t Sample.t)
   =
-  let size = Output.size output in
   let node = of_consumed @@ Output.consumed output in
   let keep t =
     let input = to_input ~size t in

--- a/src/lib/shrink.mli
+++ b/src/lib/shrink.mli
@@ -13,6 +13,7 @@ val shrink
   :  max_tries:int
   -> max_tries_modify:int
   -> num_shrink_rounds:int
+  -> size:int
   -> Proposition.t Output.t
   -> Proposition.t Sample.t
   -> result Random.t

--- a/src/lib/util.ml
+++ b/src/lib/util.ml
@@ -92,3 +92,11 @@ module Seq = struct
     | None -> Seq.Nil
     | Some (x, u') -> Cons (x, unfold f u')
 end
+
+module Timer = struct
+  let time_it f =
+    let start = Unix.gettimeofday () in
+    let res = f () in
+    let stop = Unix.gettimeofday () in
+    (res, stop -. start)
+end

--- a/src/lib/util.mli
+++ b/src/lib/util.mli
@@ -30,3 +30,7 @@ module Seq : sig
     -> unit
     -> 'a Seq.node
 end
+
+module Timer : sig
+  val time_it : (unit -> 'a) -> 'a * float
+end

--- a/test/samples.ml
+++ b/test/samples.ml
@@ -205,6 +205,19 @@ let record_with_list_length_dist =
     (fun { zs; _ } -> zs)
     t1_sample
 
+let manual_with_list_length_dist =
+  let sample =
+    let* xs = Sample.(list int) in
+    let* ys = Sample.(list int) in
+    let* zs = Sample.(list int) in
+    Sample.return (xs, ys, zs)
+  in
+  gen_dist_test
+    (fun (xs, _, _) -> xs)
+    (fun (_, ys, _) -> ys)
+    (fun (_, _, zs) -> zs)
+    sample
+
 let suite =
   suite
     [ ("Int range", int_range)
@@ -222,4 +235,5 @@ let suite =
     ; ("Record list length dist", record_with_list_length_dist)
     ; ("Derived list length dist", derived_tuple_with_list_length_dist)
     ; ("Tuple list length dist", tuple_with_list_length_dist)
+    ; ("Manual list length dist", manual_with_list_length_dist)
     ]


### PR DESCRIPTION
Addresses two issues:

1) When tests were moved around the ran with different seeds. Now they always run with the config seed. That is the random monadic values are evaluated once for each test rather than being sequenced.

2) There was a bug that caused `resize` to resize all subsequent samples. Now fixed. 