### PR TITLE
Add char, unit, int32, int64 to built-in comparators and update ppx_deriving_popper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _build
 .merlin
 .vscode
 site
+_opam

--- a/src/lib/comparator.ml
+++ b/src/lib/comparator.ml
@@ -69,6 +69,7 @@ let bytes =
     pp_print_string fmt (Bytes.unsafe_to_string a))
 
 let bool = make Bool.compare pp_print_bool
+let unit = make Unit.compare (fun fmt () -> Format.fprintf fmt "()")
 
 let option t =
   let compare = compare t in

--- a/src/lib/comparator.ml
+++ b/src/lib/comparator.ml
@@ -58,8 +58,16 @@ let array t =
     (pp_array @@ pp t)
 
 let int = make Int.compare pp_print_int
+let int32 = make Int32.compare (fun fmt a -> Format.fprintf fmt "%ld" a)
+let int64 = make Int64.compare (fun fmt a -> Format.fprintf fmt "%Ld" a)
+let char = make Char.compare pp_print_char
 let float = make Float.compare pp_print_float
 let string = make String.compare pp_print_string
+
+let bytes =
+  make Bytes.compare (fun fmt a ->
+    pp_print_string fmt (Bytes.unsafe_to_string a))
+
 let bool = make Bool.compare pp_print_bool
 
 let option t =

--- a/src/lib/comparator.mli
+++ b/src/lib/comparator.mli
@@ -4,9 +4,13 @@ val make : ('a -> 'a -> int) -> (Format.formatter -> 'a -> unit) -> 'a t
 val compare : 'a t -> 'a -> 'a -> int
 val pp : 'a t -> Format.formatter -> 'a -> unit
 val int : int t
+val int32 : int32 t
+val int64 : int64 t
 val float : float t
 val bool : bool t
+val char : char t
 val string : string t
+val bytes : bytes t
 val tuple : 'a t -> 'b t -> ('a * 'b) t
 val list : 'a t -> 'a list t
 val array : 'a t -> 'a array t

--- a/src/lib/comparator.mli
+++ b/src/lib/comparator.mli
@@ -11,6 +11,7 @@ val bool : bool t
 val char : char t
 val string : string t
 val bytes : bytes t
+val unit : unit t
 val tuple : 'a t -> 'b t -> ('a * 'b) t
 val list : 'a t -> 'a list t
 val array : 'a t -> 'a array t

--- a/src/lib/popper.mli
+++ b/src/lib/popper.mli
@@ -28,11 +28,26 @@ module Comparator : sig
   (** [int] is an integer comparator.*)
   val int : int t
 
+  (** [int32] is an int32 comparator. *)
+  val int32 : int32 t
+
+  (** [int64] is an int64 comparator. *)
+  val int64 : int64 t
+
+  (** [char] is a [char] comparator. *)
+  val char : char t
+
+  (** [unit] is an [unit] comparator. *)
+  val unit : unit t
+
   (** [float] is a float comparator. *)
   val float : float t
 
   (** [bool] is a bool comparator. *)
   val bool : bool t
+
+  (** [string] is a string comparator. *)
+  val bytes : bytes t
 
   (** [string] is a string comparator. *)
   val string : string t
@@ -162,6 +177,9 @@ module Sample : sig
   (** [bool] is a sample that produces [bool] values. *)
   val bool : bool t
 
+  (** [bytes] is a sample that produces [bytes] values. *)
+  val bytes : bytes t
+
   (** [fn s] is a sample that produces a function value. *)
   val fn : 'a t -> ('b -> 'a) t
 
@@ -287,8 +305,8 @@ module Sample : sig
         [n]. *)
     val of_length : int -> string t
 
-    (** [range min max s] is a sample that always produces a string of size [n],
-        where [min <= n < max], using the given sample [s]. *)
+    (** [range min max] is a sample that always produces a string of size [n],
+        where [min <= n < max]. *)
     val range : int -> int -> string t
 
     (** [alpha_numeric] is a sample that produces strings containing
@@ -307,6 +325,33 @@ module Sample : sig
 
     (** [upper] is sample that always produces lower-case characters. *)
     val lower : string t
+  end
+
+  module Bytes : sig
+    (** [of_length n] is a sample that always produces [bytes] of fixed size
+        [n]. *)
+    val of_length : int -> bytes t
+
+    (** [range min max] is a sample that always produces a [bytes] of size [n],
+        where [min <= n < max]. *)
+    val range : int -> int -> bytes t
+
+    (** [alpha_numeric] is a sample that produces [bytes] containing
+        alhpa-numeric characthers. *)
+    val alpha_numeric : bytes t
+
+    (** [numeric] is a sample that produces [bytes] containing numbers *)
+    val numeric : bytes t
+
+    (** [alpha] a sample that produces [bytes] containing characters a-z, both
+        upper and lower case. *)
+    val alpha : bytes t
+
+    (** [upper] is sample that always produces upper-case characters. *)
+    val upper : bytes t
+
+    (** [upper] is sample that always produces lower-case characters. *)
+    val lower : bytes t
   end
 
   module Tuple : sig

--- a/src/lib/popper.mli
+++ b/src/lib/popper.mli
@@ -350,7 +350,7 @@ module Sample : sig
     (** [upper] is sample that always produces upper-case characters. *)
     val upper : bytes t
 
-    (** [upper] is sample that always produces lower-case characters. *)
+    (** [lower] is sample that always produces lower-case characters. *)
     val lower : bytes t
   end
 

--- a/src/lib/sample.ml
+++ b/src/lib/sample.ml
@@ -327,6 +327,18 @@ module String = struct
   let lower = map of_list @@ list Char.lower
 end
 
+module Bytes = struct
+  let map' = map Bytes.unsafe_of_string
+  let bytes = map' String.string
+  let of_length n = map' @@ String.of_length n
+  let range mn mx = map' @@ String.range mn mx
+  let numeric = map' @@ String.numeric
+  let alpha_numeric = map' @@ String.alpha_numeric
+  let alpha = map' @@ String.alpha
+  let upper = map' @@ String.upper
+  let lower = map' @@ String.lower
+end
+
 module Tuple = struct
   let pair g1 g2 =
     let* size = size in
@@ -359,4 +371,5 @@ let int64 =
   Int64.of_float f
 
 let string = String.string
+let bytes = Bytes.bytes
 let char = Char.char

--- a/src/lib/sample.mli
+++ b/src/lib/sample.mli
@@ -22,6 +22,7 @@ val float : float t
 val bool : bool t
 val fn : 'a t -> ('b -> 'a) t
 val string : string t
+val bytes : bytes t
 val option : 'a t -> 'a option t
 val result : ok:'a t -> error:'b t -> ('a, 'b) result t
 val list : 'a t -> 'a list t
@@ -73,6 +74,16 @@ module String : sig
   val alpha : string t
   val upper : string t
   val lower : string t
+end
+
+module Bytes : sig
+  val of_length : int -> bytes t
+  val range : int -> int -> bytes t
+  val alpha_numeric : bytes t
+  val numeric : bytes t
+  val alpha : bytes t
+  val upper : bytes t
+  val lower : bytes t
 end
 
 module Tuple : sig

--- a/src/ppx/ppx_deriving_popper.ml
+++ b/src/ppx/ppx_deriving_popper.ml
@@ -33,6 +33,9 @@ let sample_of_type ~is_rec_type ~size ~loc = function
   | "bool" -> [%expr Popper.Sample.bool]
   | "float" -> [%expr Popper.Sample.float]
   | "int32" -> [%expr Popper.Sample.int32]
+  | "char" -> [%expr Popper.Sample.char]
+  | "unit" -> [%expr Popper.Sample.unit]
+  | "int64" -> [%expr Popper.Sample.int64]
   | t ->
     let (module A) = Ast_builder.make loc in
     let body =

--- a/src/ppx/ppx_deriving_popper.ml
+++ b/src/ppx/ppx_deriving_popper.ml
@@ -36,6 +36,7 @@ let sample_of_type ~is_rec_type ~size ~loc = function
   | "char" -> [%expr Popper.Sample.char]
   | "unit" -> [%expr Popper.Sample.unit]
   | "int64" -> [%expr Popper.Sample.int64]
+  | "bytes" -> [%expr Popper.Sample.bytes]
   | t ->
     let (module A) = Ast_builder.make loc in
     let body =

--- a/test/deriving_popper.ml
+++ b/test/deriving_popper.ml
@@ -77,6 +77,17 @@ type 'a t17 =
 
 and t18 = int t17 [@@deriving show, ord, popper]
 
+type t19 = (char, string) result [@@deriving show, ord, popper]
+
+type t20 =
+  { a : int64
+  ; b : char
+  ; c : unit
+  ; d : bool
+  ; e : int32
+  }
+[@@deriving show, ord, popper]
+
 let make_test name comparator sample =
   let open Popper in
   let open Sample.Syntax in
@@ -102,4 +113,6 @@ let suite =
     ; make_test "T14" t14_comparator t14_sample
     ; make_test "T16" t16_comparator t16_sample
     ; make_test "T18" t18_comparator t18_sample
+    ; make_test "T19" t19_comparator t19_sample
+    ; make_test "T20" t20_comparator t20_sample
     ]

--- a/test/deriving_popper.ml
+++ b/test/deriving_popper.ml
@@ -85,6 +85,7 @@ type t20 =
   ; c : unit
   ; d : bool
   ; e : int32
+  ; f : bytes
   }
 [@@deriving show, ord, popper]
 


### PR DESCRIPTION
Fixes #47.

Summary:
1. Add char, unit, int32, int64 and unit to built-in comparators
2. Add bytes and Bytes module to Sample module.
3. Updates `ppx_deriving_popper` to generate `Sample.t` code for `char, unit and int64` 
4. Update tests to exercise new functionality