### PR TITLE
Improve handling of discarded tests

### DIFF
--- a/examples/hello_world.ml
+++ b/examples/hello_world.ml
@@ -19,4 +19,11 @@ let test_rev_twice =
     let* xs = int_list_sample in
     eq_list (List.rev (List.rev xs)) xs)
 
-let suite = suite [ ("Reverse", test_rev); ("Reverse twice", test_rev_twice) ]
+let test_discarded = test (fun () -> discard)
+
+let suite =
+  suite
+    [ ("Reverse", test_rev)
+    ; ("Reverse twice", test_rev_twice)
+    ; ("A discarded test", test_discarded)
+    ]

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -7,6 +7,7 @@ type config =
   ; seed : int list
   ; verbose : bool
   ; max_input_length : int
+  ; max_num_discarded : int
   }
 
 type t = config -> config
@@ -20,6 +21,7 @@ let default =
   ; seed = [ 1; 23; 45 ]
   ; verbose = false
   ; max_input_length = 10_000
+  ; max_num_discarded = 1000
   }
 
 let num_samples num_samples c = { c with num_samples }
@@ -28,6 +30,7 @@ let seed seed c = { c with seed }
 let verbose c = { c with verbose = true }
 let max_size max_size c = { c with max_size }
 let max_input_length max_input_length c = { c with max_input_length }
+let max_num_discarded max_num_discarded c = { c with max_num_discarded }
 let all cs c = List.fold_left (fun c f -> f c) c cs
 let get_num_samples f = (f default).num_samples
 let get_max_shrinks f = (f default).max_shrinks
@@ -36,4 +39,5 @@ let get_max_size f = (f default).max_size
 let get_seed f = (f default).seed
 let get_verbose f = (f default).verbose
 let get_max_input_length f = (f default).max_input_length
+let get_max_num_discarded f = (f default).max_num_discarded
 let default = Fun.id

--- a/src/lib/config.mli
+++ b/src/lib/config.mli
@@ -6,6 +6,7 @@ val max_shrinks : int -> t
 val seed : int list -> t
 val verbose : t
 val max_input_length : int -> t
+val max_num_discarded : int -> t
 val max_size : int -> t
 val get_num_samples : t -> int
 val get_max_shrinks : t -> int
@@ -14,4 +15,5 @@ val get_max_size : t -> int
 val get_seed : t -> int list
 val get_verbose : t -> bool
 val get_max_input_length : t -> int
+val get_max_num_discarded : t -> int
 val all : t list -> t

--- a/src/lib/popper.ml
+++ b/src/lib/popper.ml
@@ -32,6 +32,7 @@ let all ps = Sample.sequence ps |> Sample.map Proposition.all
 let any ps = Sample.sequence ps |> Sample.map Proposition.any
 let pass = Sample.return Proposition.pass
 let fail ?loc s = Sample.return @@ Proposition.fail_with ?loc s
+let discard = Sample.return Proposition.discard
 let test ?(config = Config.default) = Test.make ~config
 
 let run ?(config = Config.default) t =
@@ -40,4 +41,4 @@ let run ?(config = Config.default) t =
   else
     raise Test_failure
 
-let check ?config f = run ?config (Test.make f)
+let check ?config f = run @@ test ?config f

--- a/src/lib/popper.mli
+++ b/src/lib/popper.mli
@@ -475,6 +475,8 @@ module Config : sig
   (** [all cs] combines all configuration options [cs]. In case there are
       overlaps, the values at the end of the list take precedence. *)
   val all : t list -> t
+
+  val max_num_discarded : int -> t
 end
 
 (** {1 Types and exceptions } *)
@@ -503,6 +505,9 @@ val pass : Proposition.t Sample.t
 (** [fail ?loc msg] is a sample that returns the value [fail] with location
     [loc] if given and error message [msg]. *)
 val fail : ?loc:string -> string -> Proposition.t Sample.t
+
+(** [discard] is a sample that returns the value [discard]. *)
+val discard : Proposition.t Sample.t
 
 (** [equal ?loc cmp x y] is a sample that returns a proposition that is [pass]
     only if [x] and [y] are equal using the given comparator [cmp]. If [loc] is

--- a/src/lib/test_result.ml
+++ b/src/lib/test_result.ml
@@ -131,6 +131,7 @@ let pp_results out res =
       let color =
         match status with
         | Fail _ -> red
+        | Discarded _ -> yellow
         | _ -> Util.Format.blue
       in
       Table.cell @@ fun out () ->
@@ -150,7 +151,10 @@ let pp_results out res =
             Printf.sprintf "Passed %d samples" num_passed
         | Fail { explanation; _ } -> explanation
         | Discarded { num_discarded } ->
-          Printf.sprintf "Passed %d and %d discarded" num_passed num_discarded
+          if num_passed = 0 && num_discarded = 1 then
+            Printf.sprintf "Discarded"
+          else
+            Printf.sprintf "Passed %d and %d discarded" num_passed num_discarded
       in
       Table.cell @@ fun out () -> fprintf out "%a" (faint pp_print_string) msg
     in

--- a/test/config.ml
+++ b/test/config.ml
@@ -1,0 +1,40 @@
+open Popper
+open Sample.Syntax
+
+let test_exceed_num_discarded =
+  test @@ fun () ->
+  try
+    let config = Config.max_num_discarded 50 in
+    check ~config (fun () ->
+      let* b = Sample.bool in
+      if b then
+        pass
+      else
+        discard);
+    fail "Should have thrown an exception"
+  with
+  | _ -> pass
+
+let test_some_discarded =
+  test @@ fun () ->
+  let* b = Sample.bool in
+  if b then
+    pass
+  else
+    discard
+
+let test_discard_unit =
+  test @@ fun () ->
+  try
+    (* This test should run without throwing *)
+    check (fun () -> discard);
+    pass
+  with
+  | _ -> fail "Did not expect discard to throw"
+
+let suite =
+  suite
+    [ ("Max num discarded", test_exceed_num_discarded)
+    ; ("Some discarded", test_some_discarded)
+    ; ("Discard unit", test_discard_unit)
+    ]

--- a/test/run.ml
+++ b/test/run.ml
@@ -3,6 +3,8 @@ let suite =
     [ ("Deriving Sample", Deriving_sample.suite)
     ; ("Deriving Popper", Deriving_popper.suite)
     ; ("Samples", Samples.suite)
+    ; ("Config", Config.suite)
     ]
 
-let () = Popper.run suite
+let config = Popper.Config.num_samples 1000
+let () = Popper.run ~config suite


### PR DESCRIPTION
A few things:

1) Add a configuration `max_num_discarded` for specifying that a property-based test fails if it exceeds the threshold for the number of discarded items.

2) Expose missing `Popper.discard` function.

3) Improve printing of discarded unit test.

4) Change the number of samples for the test target to `1000`.

Example:

```ocaml
let config = Config.max_num_discarded 50
let () =
  check ~config (fun () ->
    let* b = Sample.bool in
    if b then pass else discard)
```

Results in:

![image](https://user-images.githubusercontent.com/820478/122107119-a5b88a80-ce12-11eb-894f-c458bc0908e1.png)
