### PR TITLE
Support deriving array

### DIFF
--- a/src/lib/popper.mli
+++ b/src/lib/popper.mli
@@ -201,6 +201,10 @@ module Sample : sig
       parameter. *)
   val list : 'a t -> 'a list t
 
+  (** [array s] is a sample that produces an array using the give [s]. The size
+      of the array is influenced by the implicit [size] parameter. *)
+  val array : 'a t -> 'a array t
+
   (** {1 Debugging combinators } *)
 
   (** [log_key_value key value] is a sample that when run logs the given [key]

--- a/src/lib/sample.ml
+++ b/src/lib/sample.ml
@@ -150,6 +150,8 @@ let list g =
   in
   tag Tag.List @@ sized aux
 
+let array s = map Array.of_list @@ list s
+
 let option g =
   sized (fun size ->
     if size <= 1 then

--- a/src/lib/sample.mli
+++ b/src/lib/sample.mli
@@ -26,6 +26,7 @@ val bytes : bytes t
 val option : 'a t -> 'a option t
 val result : ok:'a t -> error:'b t -> ('a, 'b) result t
 val list : 'a t -> 'a list t
+val array : 'a t -> 'a array t
 val log_key_value : string -> string -> unit t
 val with_log : string -> (Format.formatter -> 'a -> unit) -> 'a t -> 'a t
 val with_consumed : 'a t -> ('a * Consumed.t) t

--- a/src/ppx/ppx_deriving_popper.ml
+++ b/src/ppx/ppx_deriving_popper.ml
@@ -119,6 +119,8 @@ and of_applied_type ~loc ~is_rec_type ~size ~name ts =
     [%expr Popper.Sample.option [%e of_core_type ~is_rec_type ~size t]]
   | "list", [ t ] ->
     [%expr Popper.Sample.list [%e of_core_type ~is_rec_type ~size t]]
+  | "array", [ t ] ->
+    [%expr Popper.Sample.array [%e of_core_type ~is_rec_type ~size t]]
   | "result", [ t1; t2 ] ->
     [%expr
       Popper.Sample.result

--- a/test/deriving_popper.ml
+++ b/test/deriving_popper.ml
@@ -89,6 +89,8 @@ type t20 =
   }
 [@@deriving show, ord, popper]
 
+type t21 = { bar : int array } [@@deriving show, ord, popper]
+
 let make_test name comparator sample =
   let open Popper in
   let open Sample.Syntax in
@@ -116,4 +118,5 @@ let suite =
     ; make_test "T18" t18_comparator t18_sample
     ; make_test "T19" t19_comparator t19_sample
     ; make_test "T20" t20_comparator t20_sample
+    ; make_test "T21" t21_comparator t21_sample
     ]

--- a/test/deriving_sample.ml
+++ b/test/deriving_sample.ml
@@ -77,6 +77,7 @@ type 'a t17 =
 and t18 = int t17 [@@deriving sample]
 
 type t19 = { fn : int -> bool } [@@deriving sample]
+type t20 = { bar : int array } [@@deriving sample]
 
 let make_test name sample =
   let open Popper in
@@ -104,4 +105,5 @@ let suite =
     ; make_test "T16" t16_sample
     ; make_test "T18" t18_sample
     ; make_test "T19" t19_sample
+    ; make_test "T20" t20_sample
     ]


### PR DESCRIPTION
Address https://github.com/jobjo/popper/issues/54. Support deriving sampler for arrays and add missing `Sample.array` combinator.