### PR TITLE
Fix range and char samplers

### DIFF
--- a/src/lib/sample.ml
+++ b/src/lib/sample.ml
@@ -101,11 +101,7 @@ let range mn mx =
   if mx <= mn then
     mn
   else
-    let n = mx - mn in
-    let n = Int32.of_int n in
-    let block = Int32.div Int32.max_int n in
-    let offset = Int32.div r block in
-    mn + Int32.to_int offset
+    (Int32.to_int r mod (mx - mn)) + mn
 
 let one_of gs =
   let* n = range 0 (List.length gs) in
@@ -200,11 +196,11 @@ module Int = struct
 
   let small =
     let pos = range 0 10 in
-    one_of [ pos; map Stdlib.Int.neg pos ]
+    choose [ (0.5, pos); (0.5, map Stdlib.Int.neg pos) ]
 
   let medium =
     let pos = range 0 1000 in
-    one_of [ pos; map Stdlib.Int.neg pos ]
+    choose [ (0.5, pos); (0.5, map Stdlib.Int.neg pos) ]
 
   let any_int =
     let* b = tag Sign int32 in
@@ -218,8 +214,8 @@ module Int = struct
     @@ choose
          [ (5., return 0)
          ; (20., return 1)
-         ; (10., return (-1))
-         ; (50., small)
+         ; (20., return (-1))
+         ; (100., small)
          ; (100., medium)
          ; (100., any_int)
          ; (2., return Int.max_int)
@@ -301,7 +297,7 @@ module Char = struct
   let numeric = map Char.chr @@ Int.range 48 58
   let alpha = choose [ (3., lower); (1., upper) ]
   let alpha_numeric = choose [ (5., lower); (2., upper); (1., numeric) ]
-  let any_char = map Char.chr @@ Int.range 0 256
+  let any_char = map Char.chr (Int.range 0 256)
 
   let char =
     choose

--- a/test/expect/exception.expected
+++ b/test/expect/exception.expected
@@ -36,7 +36,7 @@
 
   Reason:
 
-    File "test/expect/exception.ml", line 22, characters 4-10: Assertion failed
+    Not even
 
 Test Failed: 0/4 tests passed and 4 failed in XXs.
 

--- a/test/expect/exception.ml
+++ b/test/expect/exception.ml
@@ -16,7 +16,7 @@ let test_e3 =
 let test_e4 =
   test @@ fun () ->
   let* n = Sample.int in
-  if n mod 2 = 1 then
+  if n mod 2 = 0 then
     fail "Not even"
   else
     assert false

--- a/test/unit/config.ml
+++ b/test/unit/config.ml
@@ -18,7 +18,8 @@ let test_exceed_num_discarded =
   | _ -> pass
 
 let test_some_discarded =
-  test @@ fun () ->
+  let config = Config.(max_num_discarded 1100) in
+  test ~config @@ fun () ->
   let* b = Sample.bool in
   if b then
     pass

--- a/test/unit/samples.ml
+++ b/test/unit/samples.ml
@@ -47,9 +47,9 @@ let neg_pos_ratio =
   let neg = lookup `Neg in
   let zero = lookup `Zero in
   let pos = lookup `Positive in
-  let* () = Sample.log_key_value "Negative" (string_of_float neg) in
-  let* () = Sample.log_key_value "Zero" (string_of_float zero) in
-  let* () = Sample.log_key_value "Positive" (string_of_float pos) in
+  let* () = Sample.log_key_value "Negative" (Printf.sprintf "%.2f" neg) in
+  let* () = Sample.log_key_value "Zero" (Printf.sprintf "%.2f" zero) in
+  let* () = Sample.log_key_value "Positive" (Printf.sprintf "%.2f" pos) in
   all
     [ in_range 0.45 0.55 neg; in_range 0.45 0.55 pos; in_range 0.01 0.05 zero ]
 
@@ -226,9 +226,31 @@ let manual_with_list_length_dist =
     (fun (_, _, zs) -> zs)
     sample
 
+let int_range2 =
+  let config = Config.num_samples 100_000 in
+  test ~config @@ fun () ->
+  let* n = Sample.Int.range 0 256 in
+  less_than Comparator.int n 256
+
+let int_range3 =
+  test @@ fun () ->
+  let lower = Int.max_int - 10 in
+  let upper = Int.max_int in
+  let* n = Sample.Int.range lower upper in
+  all
+    [ less_than Comparator.int n upper; less_equal_than Comparator.int lower n ]
+
+let char_ok =
+  let config = Config.num_samples 100_000 in
+  test ~config @@ fun () ->
+  let* _ = Sample.char in
+  pass
+
 let suite =
   suite
     [ ("Int range", int_range)
+    ; ("Int range 2", int_range2)
+    ; ("Int range 3", int_range3)
     ; ("Int positive", int_positive)
     ; ("Int negative", int_negative)
     ; ("Float classes", float_classes)
@@ -244,4 +266,5 @@ let suite =
     ; ("Derived list length dist", derived_tuple_with_list_length_dist)
     ; ("Tuple list length dist", tuple_with_list_length_dist)
     ; ("Manual list length dist", manual_with_list_length_dist)
+    ; ("Char", char_ok)
     ]


### PR DESCRIPTION
Address https://github.com/jobjo/popper/issues/62.

Correct a bug in the `range` operator and revert to use the simple `mod` operation. There does not seem to be any performance impact.